### PR TITLE
[DOP-16967] Allow writing ArrayType(TimestampType) to Clickhouse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+## 0.0.2 (2024-10-02)
+
+* Allow writing ``ArrayType(TimestampType())` Spark column as Clickhouse's `Array(DateTime64(6))`.
+* Allow writing ``ArrayType(ShortType())` Spark column as Clickhouse's `Array(Int16)`.
+
+## 0.0.1 (2024-10-01)
+
+First release! 🎉
+
+This version includes custom Clickhouse dialect for Apache Spark 3.5.x, with following enhancements:
+* support for writing Spark's `ArrayType` to Clickhouse. Currently [only few types](https://github.com/ClickHouse/clickhouse-java/issues/1754) are supported, like `ArrayType(StringType)`, `ArrayType(ByteType)`, `ArrayType(LongType)`, `ArrayType(FloatType)`. Unfortunately, reading Arrays from Clickhouse to Spark is not fully supported for now.
+* fixed issue when writing Spark's `TimestampType` lead to creating Clickhouse table with `DateTime64(0)` instead of `DateTime64(6)`, resulting a precision loss (fractions of seconds were dropped).
+* fixed issue when writing Spark's `BooleanType` lead to creating Clickhouse table with `UInt64` column instead of `Bool`.

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ plugins {
 group = "io.github.mtsongithub.doetl"
 // TODO: crossbuild for Scala 2.13
 archivesBaseName = "spark-dialect-extension_2.12"
-version = "0.0.1"
+version = "0.0.2"
 
 repositories {
     mavenCentral()

--- a/docs/data_type_mappings.md
+++ b/docs/data_type_mappings.md
@@ -24,7 +24,8 @@ Primitive types:
 | `Decimal64(N)`         | `DecimalType(M, N)`  | `Decimal64(M, N)`       | `Decimal64(M, N)`                               |
 | `Decimal128(N)`        | `DecimalType(M, N)`  | `Decimal128(M, N)`      | `Decimal128(M, N)`                              |
 | `Decimal256(N)`        | unsupported          | unsupported             | unsupported                                     |
-| `DateTime`             | `TimestampType`      | `DateTime`              | `DateTime`                                      | 
+| `Date`                 | `DateType`           | `Date`                  | `Date`                                          |
+| `DateTime`             | `TimestampType`      | `DateTime`              | `DateTime`                                      |
 | `DateTime64(6)`        | `TimestampType`      | `DateTime64(6)`         | `DateTime64(6) (Spark's default is DateTime32)` |
 
 
@@ -34,10 +35,15 @@ Primitive types:
 |------------------------|--------------------------------|-------------------------|--------------------------|
 | `Array(String)`        | `ArrayType(StringType)`        | `Array(String)`         | `Array(String)`          |
 | unsupported            | `ArrayType(ByteType)`          | `Array(Int8)`           | `Array(Int8)`            |
-| unsupported            | `ArrayType(ShortType)`         | unsupported             | unsupported              |
+| unsupported            | `ArrayType(ShortType)`         | `Array(Int16)`          | `Array(Int16)`           |
+| unsupported            | `ArrayType(IntegerType)`       | `Array(Int32)`          | `Array(Int32)`           |
 | unsupported            | `ArrayType(LongType)`          | `Array(Int64)`          | `Array(Int64)`           |
 | `Array(Decimal(M, N))` | `ArrayType(DecimalType(M, N))` | `Array(Decimal(M, N))`  | `Array(Decimal(M, N))`   |
-| unsupported            | `ArrayType(TimestampType)`     | unsupported             | unsupported              |
-| unsupported            | `ArrayType(Date)`              | `Array(Date)`           | `Array(Date)`            |
 | unsupported            | `ArrayType(FloatType)`         | `Array(Float32)`        | `Array(Float32)`         |
-| unsupported            | `ArrayType(DoubleType)`        | unsupported             | unsupported              |
+| unsupported            | `ArrayType(DoubleType)`        | `Array(Float64)`        | `Array(Float64)`         |
+| unsupported            | `ArrayType(Date)`              | `Array(Date)`           | `Array(Date)`            |
+| unsupported            | `ArrayType(TimestampType)`     | `Array(DateTime64(6))`  | `Array(DateTime64(6))`   |
+
+Reading issues are caused by Clickhouse JDBC implementation:
+* https://github.com/ClickHouse/clickhouse-java/issues/1754
+* https://github.com/ClickHouse/clickhouse-java/issues/1409


### PR DESCRIPTION
## Change Summary

* There was a bug in matching against `DateTime` Clickhouse type. After applying a fix, users can write `ArrayType(TimestampType())` columns from Spark to Clickhouse.
* Fixed issue with writing `ArrayType(ShortType())` to Clickhouse, by changing type name to case-insensitive alias.
* Added negative test for reading some array types from Clickhouse to Spark.
* Fix type mapping table, Spark actually could create tables with Array columns. Also there were missing rows for `Date` and `Array(Int32)` column types.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [X] Commit message and PR title is comprehensive
* [X] Keep the change as small as possible
* [X] Unit and integration tests for the changes exist
* [X] Tests pass on CI and coverage does not decrease
* [X] Documentation reflects the changes where applicable
* [X] My PR is ready to review.
