### PR TITLE
[DOP-37235] Fix ClickHouse JDBC Driver 0.9.x type mapping

### DIFF
--- a/src/main/scala/io/github/mtsongithub/doetl/sparkdialectextensions/clickhouse/spark35/ClickhouseDialectExtension.scala
+++ b/src/main/scala/io/github/mtsongithub/doetl/sparkdialectextensions/clickhouse/spark35/ClickhouseDialectExtension.scala
@@ -68,7 +68,7 @@ private object ClickhouseDialectExtension extends JdbcDialect {
   private def toCatalystType(typeName: String): Option[(Boolean, DataType)] = {
     val (nullable, _typeName) = unwrapNullable(typeName)
     val dataType = _typeName match {
-      case "String" =>
+      case "String" | "IPv4" | "IPv6" | "UUID" =>
         logger.debug(s"Custom mapping applied: StringType for '${_typeName}'")
         Some(StringType)
       case "Int8" =>

--- a/src/test/scala/io/github/mtsongithub/doetl/sparkdialectextensions/clickhouse/ClickhouseDialectTest.scala
+++ b/src/test/scala/io/github/mtsongithub/doetl/sparkdialectextensions/clickhouse/ClickhouseDialectTest.scala
@@ -506,6 +506,72 @@ class ClickhouseDialectTest
         java.sql.Date.valueOf("2023-12-31")))
   }
 
+  test("read ClickHouse IPv4 as Spark StringType") {
+    setupTable("ipv4Column IPv4")
+    insertTestData(
+      Seq("('0.0.0.0')", "('255.255.255.255')")
+    )
+
+    val df = spark.read
+      .format("jdbc")
+      .option("url", jdbcUrl)
+      .option("user", jdbcUser)
+      .option("password", jdbcPassword)
+      .option("dbtable", tableName)
+      .load()
+
+    assert(df.schema.fields.head.dataType == StringType)
+
+    val data = df.collect().map(_.getString(0)).sorted
+    assert(data sameElements Array("0.0.0.0", "255.255.255.255"))
+  }
+
+  test("read ClickHouse IPv6 as Spark StringType") {
+    setupTable("ipv6Column IPv6")
+    insertTestData(
+      Seq("('2001:db8::42')", "('dbd6:a34d:7835:c75:304f:6c73:edac:957b')")
+    )
+
+    val df = spark.read
+      .format("jdbc")
+      .option("url", jdbcUrl)
+      .option("user", jdbcUser)
+      .option("password", jdbcPassword)
+      .option("dbtable", tableName)
+      .load()
+
+    assert(df.schema.fields.head.dataType == StringType)
+
+    val data = df.collect().map(_.getString(0)).sorted
+    assert(data sameElements Array(
+      "2001:db8:0:0:0:0:0:42",
+      "dbd6:a34d:7835:c75:304f:6c73:edac:957b")
+    )
+  }
+
+  test("read ClickHouse UUID as Spark StringType") {
+    setupTable("uuidColumn UUID")
+    insertTestData(
+      Seq("('483971cf-aad7-4c84-abf1-4a94c9d72f99')", "('8f3c71a9-b4d2-40e1-95c8-63a2b74051f9')")
+    )
+
+    val df = spark.read
+      .format("jdbc")
+      .option("url", jdbcUrl)
+      .option("user", jdbcUser)
+      .option("password", jdbcPassword)
+      .option("dbtable", tableName)
+      .load()
+
+    assert(df.schema.fields.head.dataType == StringType)
+
+    val data = df.collect().map(_.getString(0)).sorted
+    assert(data sameElements Array(
+      "483971cf-aad7-4c84-abf1-4a94c9d72f99",
+      "8f3c71a9-b4d2-40e1-95c8-63a2b74051f9")
+    )
+  }
+
   test("read ClickHouse DateTime as Spark TimestampType") {
     setupTable("datetimeColumn DateTime")
     insertTestData(Seq("('2023-01-01 12:34:56')", "('2023-12-31 23:59:59')"))
@@ -657,6 +723,18 @@ class ClickhouseDialectTest
     (
       "charArrayColumn Array(String)",
       "(['a', 'b', 'c', 'd', 'e'])",
+      ArrayType(StringType, containsNull = false)),
+    (
+      "ipv4ArrayColumn Array(IPv4)",
+      "(['0.0.0.0', '192.168.1.1', '255.255.255.255'])",
+      ArrayType(StringType, containsNull = false)),
+    (
+      "ipv6ArrayColumn Array(IPv6)",
+      "(['2001:db8::42', 'dbd6:a34d:7835:c75:304f:6c73:edac:957b'])",
+      ArrayType(StringType, containsNull = false)),
+    (
+      "uuidArrayColumn Array(UUID)",
+      "(['483971cf-aad7-4c84-abf1-4a94c9d72f99', '8f3c71a9-b4d2-40e1-95c8-63a2b74051f9'])",
       ArrayType(StringType, containsNull = false)),
     (
       "byteArrayColumn Array(Int8)",

--- a/src/test/scala/io/github/mtsongithub/doetl/sparkdialectextensions/clickhouse/ClickhouseDialectTest.scala
+++ b/src/test/scala/io/github/mtsongithub/doetl/sparkdialectextensions/clickhouse/ClickhouseDialectTest.scala
@@ -508,9 +508,7 @@ class ClickhouseDialectTest
 
   test("read ClickHouse IPv4 as Spark StringType") {
     setupTable("ipv4Column IPv4")
-    insertTestData(
-      Seq("('0.0.0.0')", "('255.255.255.255')")
-    )
+    insertTestData(Seq("('0.0.0.0')", "('255.255.255.255')"))
 
     val df = spark.read
       .format("jdbc")
@@ -528,9 +526,7 @@ class ClickhouseDialectTest
 
   test("read ClickHouse IPv6 as Spark StringType") {
     setupTable("ipv6Column IPv6")
-    insertTestData(
-      Seq("('2001:db8::42')", "('dbd6:a34d:7835:c75:304f:6c73:edac:957b')")
-    )
+    insertTestData(Seq("('2001:db8::42')", "('dbd6:a34d:7835:c75:304f:6c73:edac:957b')"))
 
     val df = spark.read
       .format("jdbc")
@@ -543,17 +539,14 @@ class ClickhouseDialectTest
     assert(df.schema.fields.head.dataType == StringType)
 
     val data = df.collect().map(_.getString(0)).sorted
-    assert(data sameElements Array(
-      "2001:db8:0:0:0:0:0:42",
-      "dbd6:a34d:7835:c75:304f:6c73:edac:957b")
-    )
+    assert(
+      data sameElements Array("2001:db8:0:0:0:0:0:42", "dbd6:a34d:7835:c75:304f:6c73:edac:957b"))
   }
 
   test("read ClickHouse UUID as Spark StringType") {
     setupTable("uuidColumn UUID")
     insertTestData(
-      Seq("('483971cf-aad7-4c84-abf1-4a94c9d72f99')", "('8f3c71a9-b4d2-40e1-95c8-63a2b74051f9')")
-    )
+      Seq("('483971cf-aad7-4c84-abf1-4a94c9d72f99')", "('8f3c71a9-b4d2-40e1-95c8-63a2b74051f9')"))
 
     val df = spark.read
       .format("jdbc")
@@ -566,10 +559,10 @@ class ClickhouseDialectTest
     assert(df.schema.fields.head.dataType == StringType)
 
     val data = df.collect().map(_.getString(0)).sorted
-    assert(data sameElements Array(
-      "483971cf-aad7-4c84-abf1-4a94c9d72f99",
-      "8f3c71a9-b4d2-40e1-95c8-63a2b74051f9")
-    )
+    assert(
+      data sameElements Array(
+        "483971cf-aad7-4c84-abf1-4a94c9d72f99",
+        "8f3c71a9-b4d2-40e1-95c8-63a2b74051f9"))
   }
 
   test("read ClickHouse DateTime as Spark TimestampType") {


### PR DESCRIPTION
## Change Summary

Fix ClickHouse JDBC Driver 0.9.x UUID, IPv4, IPv6 mappings for Spark compatibility

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] Commit message and PR title is comprehensive
* [ ] Keep the change as small as possible
* [ ] Unit and integration tests for the changes exist
* [ ] Tests pass on CI and coverage does not decrease
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review.
